### PR TITLE
Picky lint rules & some doc strings.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Copyright (c) 2023 Serval Computing
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Subject to the terms and conditions of this license, each copyright holder and contributor hereby grants to those receiving rights under this license a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except for failure to satisfy the conditions of this license) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer this software, where such license applies only to those patent claims, already acquired or hereafter acquired, licensable by such copyright holder or contributor that are necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright holders and non-copyrightable additions of contributors, in source or binary form) alone; or
+(b) combination of their Contribution(s) with the work of authorship to which such Contribution(s) was added by such copyright holder or contributor, if, at the time the Contribution is added, such addition causes such combination to be necessarily infringed. The patent license shall not apply to any other combinations which include the Contribution.
+Except as expressly stated above, no rights or licenses from any copyright holder or contributor is granted under this license, whether expressly, by implication, estoppel or otherwise.
+
+DISCLAIMER
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This port number needs to be the same for all of the peers that want to discover
 At any point, you can retrieve the mesh's fingerprint and a list of all known peers:
 
 ```rust
-let fingerprint = kaboodle.get_fingerprint().await;
-let peers = kaboodle.get_peers().await;
+let fingerprint = kaboodle.fingerprint().await;
+let peers = kaboodle.peers().await;
 println!("{fingerprint} {peers:?}");
 ```
 
@@ -36,3 +36,7 @@ At this point, Kaboodle only supports IPv4. This is for reasons of expedience an
 This project uses [just](https://github.com/casey/just) (`brew install just`) for development workflows and automation. Run `just` with no arguments to see a list of available commands.
 
 `cargo run` will run a demo application that looks for peers via port 7475. If you have [zellij](https://zellij.dev) (`brew install zellij`) installed, you can run `just run2x2` to run four copies of the demo app in a 2x2 grid. Try quitting some of the instances and see how the remaining instances discover their absence; each pane has a title above it showing that instance's IP address and port number, as well as the mesh fingerprint from the perspective of that node.
+
+## LICENSE
+
+[BSD-2-Clause-Patent](./LICENSE)

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ help:
     cargo nextest run --all-targets
 
 # Lint and automatically fix what we can fix
-@lint:
+@fix:
     cargo clippy --fix --allow-dirty --allow-staged
     cargo fmt
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
     // Begin discovering peers
     kaboodle.start().await;
 
-    let Some(self_addr) = &kaboodle.get_self_addr() else {
+    let Some(self_addr) = &kaboodle.self_addr() else {
         panic!("Expected us to have a self address by now");
     };
     set_terminal_title(&self_addr.to_string());
@@ -30,14 +30,14 @@ async fn main() {
 
     loop {
         // Dump our list of peers out
-        let known_peers = kaboodle.get_peer_states().await;
+        let known_peers = kaboodle.peer_states().await;
         if known_peers.len() < 2 {
             //  Note: we're always in the list of peers, hence the length check rather than an .is_empty()
             log::info!("== Peers: none");
             set_terminal_title(&self_addr.to_string());
         } else {
             let num_peers = known_peers.len();
-            let fingerprint = kaboodle.get_fingerprint().await;
+            let fingerprint = kaboodle.fingerprint().await;
             let fingerprint = &fingerprint[0..8];
             log::info!("== Peers: {} ({})", num_peers, fingerprint);
             for (peer, peer_state) in known_peers.iter() {

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -1,3 +1,5 @@
+//! This utility module contains some network interface conveniences.
+
 use if_addrs::{IfAddr, Ifv4Addr};
 
 use std::net::Ipv4Addr;

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -34,7 +34,7 @@ impl Display for PeerState {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum RunState {
     NotStarted,
     Running,


### PR DESCRIPTION
Also, removed the `get_` prefix from all functions that had it. Added a licence file to match the one declared in the Cargo.toml.

Finally, the networking submodule doesn't need to be public because we don't need to export those convenience functions as part of the crate's features.