### PR TITLE
IPv6 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
 name = "async-trait"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +237,7 @@ dependencies = [
 name = "kaboodle"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bincode",
  "crc32fast",
@@ -245,6 +252,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
+ "thiserror",
  "tokio",
 ]
 
@@ -552,6 +560,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "if-addrs 0.8.0",
  "log",
  "mdns-sd",
+ "network-interface",
  "rand",
  "rand_chacha",
  "serde",
@@ -316,6 +317,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "network-interface"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0bc4480c4518eb8b2599ae2dd7a97b231178ad8fb9a3e6a854fd48a5f54e95c"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.10.0"
 if-addrs = "0.8.0"
 log = "0.4.17"
 mdns-sd = {version = "0.5.10", features = ["async"]}
+network-interface = "0.1.6"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = "1.0.152"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.67"
 version = "0.1.0"
 
 [dependencies]
+anyhow = "1.0.69"
 async-trait = "0.1.64"
 bincode = "1.3.3"
 crc32fast = "1.3.2"
@@ -30,4 +31,5 @@ rand_chacha = "0.3.1"
 serde = "1.0.152"
 serde_derive = "1.0.152"
 socket2 = "0.4.7"
+thiserror = "1.0.38"
 tokio = {version = "1.25.0", features = ["full"]}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -5,6 +7,12 @@ pub enum KaboodleError {
     /// A conversion for std:io:Error
     #[error("std::io::Error: {0}")]
     IoError(#[from] std::io::Error),
+
+    #[error("No available interfaces meet our requirements")]
+    NoAvailableInterfaces,
+
+    #[error("Unable to find interface number for the given networking interface")]
+    UnableToFindInterfaceNumber,
 
     #[error("Unable to stop: {0}")]
     StoppingFailed(String),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum KaboodleError {
+    /// A conversion for std:io:Error
+    #[error("std::io::Error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Unable to stop: {0}")]
+    StoppingFailed(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,11 +124,9 @@ impl Kaboodle {
         let Some(interface) = preferred_interface.or_else(|| {
             // If no interface was provided, use the first IPv6 interface we find, and if there are
             // no IPv6 interfaces, use the first IPv4 interface.
-            let (ipv6interfaces, ipv4interfaces): (Vec<Interface>, Vec<Interface>) = non_loopback_interfaces()
-                .into_iter()
-                .partition(|iface| matches!(iface.addr, IfAddr::V6(_)));
-
-            ipv6interfaces.get(0).or_else(|| ipv4interfaces.get(0)).cloned()
+            let non_loopbacks = non_loopback_interfaces();
+            let first_ipv6_interface = non_loopbacks.iter().find(|xs| matches!(xs.addr, IfAddr::V6(_)));
+            first_ipv6_interface.or_else(|| non_loopbacks.first()).cloned()
         }) else {
             return Err(KaboodleError::NoAvailableInterfaces);
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,13 @@ impl Kaboodle {
         }
         self.state = RunState::Stopped;
 
+        // Remove ourself from the known peers list and forget about our soon-to-be-previous
+        // self_addr.
+        if let Some(self_addr) = self.self_addr.take() {
+            let mut known_peers = self.known_peers.lock().await;
+            known_peers.remove(&self_addr);
+        }
+
         let Some(cancellation_tx) = self.cancellation_tx.take() else {
             // This should not happen
             log::warn!("Unable to cancel daemon thread because we have no communication channel; this is a programming error.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{thread::sleep, time::Duration};
+use std::{process::exit, thread::sleep, time::Duration};
 
 use dotenvy::dotenv;
 use kaboodle::Kaboodle;
@@ -20,7 +20,10 @@ async fn main() {
     let mut kaboodle = Kaboodle::new(7475);
 
     // Begin discovering peers
-    kaboodle.start().await;
+    if let Err(err) = kaboodle.start().await {
+        log::error!("Failed to start: {err:?}");
+        exit(1);
+    }
 
     let Some(self_addr) = &kaboodle.self_addr() else {
         panic!("Expected us to have a self address by now");

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,9 @@ async fn main() {
         exit(1);
     }
 
-    let Some(self_addr) = &kaboodle.self_addr() else {
-        panic!("Expected us to have a self address by now");
-    };
+    let self_addr = &kaboodle
+        .self_addr()
+        .expect("We should have a self address by now");
     set_terminal_title(&self_addr.to_string());
     log::info!("I am {self_addr}");
 

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -80,11 +80,11 @@ pub fn create_broadcast_sockets(
                 sock.set_only_v6(true)?;
                 sock.set_reuse_address(true)?;
                 sock.set_reuse_port(true)?;
-
                 sock.bind(&SockAddr::from(SocketAddr::new(
                     Ipv6Addr::UNSPECIFIED.into(),
                     *broadcast_port,
                 )))?;
+
                 UdpSocket::from_std(sock.into())?
             };
             let broadcast_out_sock = {

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -1,5 +1,4 @@
 //! This utility module contains some network interface conveniences.
-#![allow(missing_docs)]
 
 use if_addrs::Interface;
 use network_interface::NetworkInterfaceConfig;

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -1,28 +1,128 @@
 //! This utility module contains some network interface conveniences.
+#![allow(missing_docs)]
 
-use if_addrs::{IfAddr, Ifv4Addr};
+use if_addrs::Interface;
+use network_interface::NetworkInterfaceConfig;
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
+use tokio::net::UdpSocket;
 
-use std::net::Ipv4Addr;
+use super::errors::KaboodleError;
 
-/// Get all non-loopback ipv4 addresses for this host.
-pub fn my_ipv4_addrs() -> Vec<Ipv4Addr> {
-    my_ipv4_interfaces().iter().map(|i| i.ip).collect()
+/// Creates a pair of sockets for receiving and sending multicast messages on the given port with
+/// the given  interface.
+pub fn create_broadcast_sockets(
+    interface: &Interface,
+    broadcast_port: &u16,
+) -> Result<(UdpSocket, UdpSocket, SocketAddr), KaboodleError> {
+    match interface.ip() {
+        IpAddr::V4(_) => {
+            // IPv4:
+            // - for listening to broadcasts, we need to bind our socket to 0.0.0.0:<port>
+            // - for sending broadcasts, we need to send to 255.255.255.255:<port>.
+            let broadcast_inbound_addr = SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(0, 0, 0, 0),
+                *broadcast_port,
+            ));
+            let broadcast_outbound_addr = SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(255, 255, 255, 255),
+                *broadcast_port,
+            ));
+            let broadcast_raw_sock: std::net::UdpSocket = {
+                let broadcast_sock =
+                    Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).unwrap();
+                broadcast_sock.set_broadcast(true).unwrap();
+                broadcast_sock.set_nonblocking(true).unwrap();
+                broadcast_sock.set_reuse_address(true).unwrap();
+                broadcast_sock.set_reuse_port(true).unwrap();
+                broadcast_sock
+                    .bind(&SockAddr::from(broadcast_inbound_addr))
+                    .expect("Failed to bind for broadcast");
+                broadcast_sock.into()
+            };
+
+            // Unlike IPv6, we can use a single socket for both sending and receiving broadcasts,
+            // but consistency for consuming code, it makes sense to return two here as well.
+            let broadcast_in_sock = UdpSocket::from_std(broadcast_raw_sock.try_clone()?)?;
+            let broadcast_out_sock = UdpSocket::from_std(broadcast_raw_sock)?;
+
+            Ok((
+                broadcast_in_sock,
+                broadcast_out_sock,
+                broadcast_outbound_addr,
+            ))
+        }
+        IpAddr::V6(_) => {
+            // IPv6:
+            // - for listening to broadcasts, we have to join a multicast IP address.
+            // - for sending broadcast messages, we have to explicitly tell the socket which
+            //   network interface to use, otherwise it won't have a route to the multicast IP.
+
+            let Some(interface_idx) = get_interface_number(interface) else {
+                return Err(KaboodleError::UnableToFindInterfaceNumber);
+            };
+
+            // All IPv6 IP addresses in the ff00::/8 prefix are multicast addresses. The first 16
+            // bits of the IP indicate the "multicast group", and the remaining 112 bits are the
+            // "group ID". A prefix of 0xff02 indicates link-local multicast, where "link-local"
+            // means the traffic won't pass beyond the local router.
+            // Broadly speaking, we can use whatever group ID we like, so long as it doesn't
+            // conflict with any well-known services.
+            // See https://www.ciscopress.com/articles/article.asp?p=2803866&seqNum=5 for more
+            // information about IPv6 multicast addresses.
+            let broadcast_ip_addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0x1213, 0x1989);
+
+            let broadcast_socket_addr =
+                SocketAddr::new(IpAddr::V6(broadcast_ip_addr), *broadcast_port);
+            let broadcast_in_sock = {
+                let sock = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))?;
+                sock.join_multicast_v6(&broadcast_ip_addr, interface_idx)?;
+                sock.set_nonblocking(true)?;
+                sock.set_only_v6(true)?;
+                sock.set_reuse_address(true)?;
+                sock.set_reuse_port(true)?;
+
+                sock.bind(&SockAddr::from(SocketAddr::new(
+                    Ipv6Addr::UNSPECIFIED.into(),
+                    *broadcast_port,
+                )))?;
+                UdpSocket::from_std(sock.into())?
+            };
+            let broadcast_out_sock = {
+                let sock = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))?;
+                sock.set_multicast_if_v6(interface_idx)?;
+                sock.set_nonblocking(true)?;
+                sock.set_reuse_address(true)?;
+                sock.set_reuse_port(true)?;
+                sock.bind(&SockAddr::from(SocketAddr::new(
+                    Ipv6Addr::UNSPECIFIED.into(),
+                    0,
+                )))?;
+
+                UdpSocket::from_std(sock.into())?
+            };
+
+            Ok((broadcast_in_sock, broadcast_out_sock, broadcast_socket_addr))
+        }
+    }
 }
 
-/// An implementation detail of my_ipv4_addrs
-fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
+/// Gets the interface number for the given interface
+/// (This is what you'd see as 'index' in `ifconfig -v` and is required for setting up multicast
+/// routes for IPv6 sockets.)
+pub fn get_interface_number(interface: &Interface) -> Option<u32> {
+    network_interface::NetworkInterface::show()
+        .unwrap_or_default()
+        .into_iter()
+        .find(|int| int.name == interface.name)
+        .map(|int| int.index)
+}
+
+/// Get all non-loopback interfaces for this host.
+pub fn non_loopback_interfaces() -> Vec<Interface> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|i| {
-            if i.is_loopback() {
-                None
-            } else {
-                match i.addr {
-                    IfAddr::V4(ifv4) => Some(ifv4),
-                    _ => None,
-                }
-            }
-        })
+        .filter(|addr| !addr.is_loopback())
         .collect()
 }


### PR DESCRIPTION
[Screencast](https://asciinema.org/a/RpYFJdLeVSiHsdp1Ypd0yORhJ)

This is a pretty big change conceptually, although the code implications aren't too bad. I'm going to sprinkle GitHub comments through the code itself to highlight interesting bits. 

Most of the time on this was spent learning about IPv6 in general and multicasting in particular. IPv6 has a few well-known IP ranges to use for listening to multicast broadcasts, and you broadcast by sending to 0.0.0.0 with whatever port you're all listening on. IPv6 works very differently; every IP starting with `ff00` through `ffff` is a multicast address. The first 8 bits are always `ff` and the next two are flags indicating the multicast group that we're a part of—we're using `ff02`, which means "everyone on this local network". The remainder of the address space is totally up for grabs—so long as we don't collide with anyone else (including on port number), we should be fine.

Kaboodle now allows you to pass in a network interface for it to use. If you don't provide one, it'll pick for you: the first IPv6 interface it comes across, or if there are none, the first IPv4 interface. The demo app lets you specify an interface as a command line parameter:

- `cargo run ipv4` picks the first IPv4 interface
- `cargo run ipv6` picks the first IPv6 interface
- `cargo run en0` picks the interface with the given name, although whether it'll use IPv4 or IPv6 is undefined behaviour
- `cargo run 192.168.5.169` picks the interface with the given IPv4 address
- `cargo run fdfb:bb2e:cb53:1:1c9f:605c:edb4:8f9` picks the interface with the given IPv6 address
 
I don't expect us to ever use anything other than the first two, but 🤷.

## Callouts
- IPv4 and IPv6 Kaboodle meshes will not see or interact with each other. This is probably something we could change, but keeping things separate for now seems reasonable.
- Multicasting on Windows works differently, and we will definitely have a bit of work to do if we want to support that.

## Recommended reading
- [IPv6 Address Representation and Address Types](https://www.ciscopress.com/articles/article.asp?p=2803866&seqNum=5)
- [simple-dns](https://github.com/balliegojr/simple-dns)'s code in general, but [socket_helper.rs](https://github.com/balliegojr/simple-dns/blob/main/simple-mdns/src/socket_helper.rs) in particular
- [Multicasting in Rust](https://bluejekyll.github.io/blog/posts/multicasting-in-rust/)