### PR TITLE
If we fail to send a ping, remove the peer from our known_peers list immediately

### DIFF
--- a/src/kaboodle.rs
+++ b/src/kaboodle.rs
@@ -561,7 +561,14 @@ impl KaboodleInner {
 
         // Comment out the following line to test indirect pinging
         if let Err(err) = self.send_msg(target_peer, &SwimMessage::Ping).await {
-            log::warn!("Failed to send ping to randomly-selected peer {target_peer}: {err:?}");
+            // TODO: we could request an indirect ping from other peers, or remove target_peer and
+            // broadcast SwimBroadcast::Failed to the mesh, but for now, let's just remove them from
+            // our known_peers list and let the problem sort itself out naturally. If the peer is
+            // genuinely gone, every other peer in the mesh will eventually figure that out on their
+            // own.
+            log::warn!("Failed to send ping to randomly-selected peer {target_peer}: {err:?}; assuming they're down immediately");
+            let mut known_peers = self.known_peers.lock().await;
+            known_peers.remove(target_peer);
         }
     }
 


### PR DESCRIPTION
This is a quick-and-dirty fix that probably deserves more thought, hence the TODO.

I encountered this after sleeping my laptop while a mesh was running and waking it up on another network -- some of the peers had been running on another machine, and were no longer accessible. The pings failed to send, but since we just logged a warning without removing the target peers, they stuck around forever.