### PR TITLE
Functions to be alerted when new peers are discovered

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,4 +18,7 @@ pub enum KaboodleError {
 
     #[error("Unable to stop: {0}")]
     StoppingFailed(String),
+
+    #[error("Functionality unavailable because the mesh is not currently running")]
+    NotRunning,
 }

--- a/src/kaboodle.rs
+++ b/src/kaboodle.rs
@@ -246,7 +246,7 @@ impl KaboodleInner {
                             state: PeerState::Known(Instant::now()),
                         };
                         let mut known_peers = self.known_peers.lock().await;
-                        known_peers.insert(addr, peer_info) == None
+                        known_peers.insert(addr, peer_info).is_none()
                     };
                     if is_new_peer {
                         self.handle_new_peer_discovered(addr, identity).await;
@@ -331,7 +331,7 @@ impl KaboodleInner {
                     identity: env.identity.clone(),
                     state: PeerState::Known(Instant::now()),
                 };
-                known_peers.insert(sender, peer_info) == None
+                known_peers.insert(sender, peer_info).is_none()
             };
             if is_new_peer {
                 self.handle_new_peer_discovered(sender, env.identity).await;
@@ -383,7 +383,7 @@ impl KaboodleInner {
                         Instant::now().checked_sub(MAX_PEER_SHARE_AGE).unwrap();
                     for (peer, identity) in peers_to_add.iter() {
                         known_peers.insert(
-                            peer.clone(),
+                            *peer,
                             PeerInfo {
                                 identity: identity.clone(),
                                 state: PeerState::Known(too_old_to_share_timestamp),

--- a/src/kaboodle.rs
+++ b/src/kaboodle.rs
@@ -3,7 +3,7 @@
 use crate::errors::KaboodleError;
 use crate::networking::create_broadcast_sockets;
 use crate::structs::{
-    KnownPeers, Peer, PeerInfo, PeerState, SwimBroadcast, SwimEnvelope, SwimMessage,
+    Fingerprint, KnownPeers, Peer, PeerInfo, PeerState, SwimBroadcast, SwimEnvelope, SwimMessage,
 };
 use bytes::Bytes;
 use if_addrs::Interface;
@@ -65,7 +65,7 @@ const REBROADCAST_INTERVAL: Duration = Duration::from_millis(10000);
 /// Because our only goal is to detect differences between two peer's understanding of the mesh,
 /// rather than guard against malicious tampering, CRC32 is a good fit: it's sufficiently robust for
 /// the task at hand, fast to compute, and has a very compact representation (a single u32).
-pub fn generate_fingerprint(known_peers: &KnownPeers) -> u32 {
+pub fn generate_fingerprint(known_peers: &KnownPeers) -> Fingerprint {
     let mut hosts: Vec<String> = known_peers.keys().map(|peer| peer.to_string()).collect();
     hosts.sort();
     crc32fast::hash(hosts.join(",").as_bytes())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,6 @@ impl Kaboodle {
                 // First, remove any channels that have been closed:
                 let indices_to_remove: Vec<usize> = discovery_tx
                     .iter()
-                    // .rev()
                     .enumerate()
                     .filter_map(|(idx, tx)| if tx.is_closed() { Some(idx) } else { None })
                     .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,12 +76,6 @@ impl Kaboodle {
     /// instance over time, you can use this field. It is treated as an opaque blob internally and
     /// can be used to store anything, but should be kept as small as possible since it is included
     /// in most of Kabdoodle's network transmissions.
-    ///
-    /// `payload` is a blob of bytes used for whatever purpose you like. Payloads are fetched from
-    /// peers on-demand, so there is no overhead for using them, although they are still transmitted
-    /// via UDP, so they shouldn't be excessively large. Payloads are appropriate for sharing small
-    /// key/value stores of data about peers, e.g. port numbers for communicating with another
-    /// service running on that node.
     pub fn new(
         broadcast_port: u16,
         preferred_interface: Option<Interface>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ impl Kaboodle {
         assert!(self.self_addr.is_none());
 
         self.state = RunState::Running;
-        let (self_addr, cancellation_tx) = KaboodleInner::start(
+        let mut result = KaboodleInner::start(
             &self.interface,
             self.broadcast_port,
             self.known_peers.clone(),
@@ -119,8 +119,8 @@ impl Kaboodle {
         )
         .await?;
 
-        self.self_addr = Some(self_addr);
-        self.cancellation_tx = Some(cancellation_tx);
+        self.self_addr = Some(result.self_addr);
+        self.cancellation_tx = Some(result.cancellation_tx);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@ mod kaboodle;
 pub mod networking;
 mod structs;
 
+type DiscoverySenders = Vec<UnboundedSender<(Peer, Bytes)>>;
+
 /// Data managed by a Kaboodle mesh client.
 #[derive(Debug)]
 pub struct Kaboodle {
@@ -60,7 +62,7 @@ pub struct Kaboodle {
     broadcast_port: u16,
     self_addr: Option<SocketAddr>,
     cancellation_tx: Option<Sender<()>>,
-    discovery_tx: Arc<Mutex<Vec<UnboundedSender<(Peer, Bytes)>>>>,
+    discovery_tx: Arc<Mutex<DiscoverySenders>>,
     interface: Interface,
     identity: Bytes,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,11 +105,22 @@ async fn main() {
         });
     }
 
-    // Write out a message the first time a new peer is discovered
+    // Write out a message the very first time a new peer is discovered
     if let Ok(discovery_rx) = kaboodle.discover_next_peer() {
         tokio::spawn(async move {
             if let Ok(new_peer) = discovery_rx.await {
                 log::info!("First peer discovered! {new_peer:?}");
+            }
+        });
+    }
+
+    // Write out a message any time a peer leaves
+    if let Ok(mut departure_rx) = kaboodle.discover_departures() {
+        tokio::spawn(async move {
+            loop {
+                if let Some(new_peer) = departure_rx.recv().await {
+                    log::info!("Peer left: {new_peer:?}");
+                }
             }
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,17 @@ async fn main() {
         });
     }
 
+    // Write out a message any time a peer leaves
+    if let Ok(mut fingerprint_rx) = kaboodle.discover_fingerprint_changes() {
+        tokio::spawn(async move {
+            loop {
+                if let Some(fingerprint) = fingerprint_rx.recv().await {
+                    log::info!("Fingerprint is now {fingerprint}");
+                }
+            }
+        });
+    }
+
     loop {
         // Dump our list of peers out
         let known_peers = kaboodle.peer_states().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,26 @@ async fn main() {
 
     let mut prev_title = String::from("");
 
+    // Write out a message any time a new peer is discovered
+    if let Ok(mut discovery_rx) = kaboodle.discover_peers() {
+        tokio::spawn(async move {
+            loop {
+                if let Some(new_peer) = discovery_rx.recv().await {
+                    log::info!("New peer discovered! {new_peer:?}");
+                }
+            }
+        });
+    }
+
+    // Write out a message the first time a new peer is discovered
+    if let Ok(discovery_rx) = kaboodle.discover_next_peer() {
+        tokio::spawn(async move {
+            if let Ok(new_peer) = discovery_rx.await {
+                log::info!("First peer discovered! {new_peer:?}");
+            }
+        });
+    }
+
     loop {
         // Dump our list of peers out
         let known_peers = kaboodle.peer_states().await;

--- a/src/observable_hashmap.rs
+++ b/src/observable_hashmap.rs
@@ -1,0 +1,166 @@
+#![allow(missing_docs)]
+
+use std::{
+    collections::{
+        hash_map::{Iter, Keys},
+        HashMap,
+    },
+    hash::Hash,
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+#[derive(Clone, Copy, Debug)]
+pub enum Event<K, V>
+where
+    K: Clone + Copy,
+{
+    Added(K),
+    Updated(K, V, V),
+    Removed(K),
+}
+
+type Observer<K, V> = UnboundedSender<Event<K, V>>;
+
+#[derive(Debug)]
+pub struct ObservableHashMap<K, V>
+where
+    K: Clone + Copy,
+{
+    map: HashMap<K, V>,
+    observers: Arc<Mutex<Vec<Observer<K, V>>>>,
+}
+
+impl<K, V> ObservableHashMap<K, V>
+where
+    K: Copy + Clone + Eq + Hash + PartialEq,
+    V: Clone + PartialEq,
+{
+    pub fn new() -> ObservableHashMap<K, V> {
+        ObservableHashMap::from(HashMap::new())
+    }
+
+    pub fn from(map: HashMap<K, V>) -> ObservableHashMap<K, V> {
+        ObservableHashMap {
+            map,
+            observers: Arc::new(Mutex::new(vec![])),
+        }
+    }
+
+    fn notify_observers(&self, event: Event<K, V>) {
+        let mut observers = self.observers.lock().unwrap();
+
+        // Notify remaining observers
+        let mut indices_to_remove = vec![];
+        for (idx, tx) in observers.iter().enumerate() {
+            if tx.send(event.to_owned()).is_err() {
+                // Channel must be closed ¯\_(ツ)_/¯
+                indices_to_remove.push(idx);
+            }
+        }
+        for idx in indices_to_remove {
+            observers.remove(idx);
+        }
+    }
+
+    pub fn add_observer(&mut self) -> UnboundedReceiver<Event<K, V>> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let mut observers = self.observers.lock().unwrap();
+        observers.push(tx);
+
+        rx
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.map.contains_key(key)
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.map.get(key)
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        let prev_value = self.map.insert(key, value);
+
+        let event = if let Some(prev_value) = prev_value.as_ref() {
+            let value = self.map.get(&key).unwrap();
+            Event::Updated(key, prev_value.clone(), value.clone())
+        } else {
+            Event::Added(key)
+        };
+        self.notify_observers(event);
+
+        prev_value
+    }
+
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        self.map.iter()
+    }
+
+    pub fn keys(&self) -> Keys<'_, K, V> {
+        self.map.keys()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        let prev_value = self.map.remove(key);
+
+        if prev_value.is_some() {
+            self.notify_observers(Event::Removed(key.to_owned()));
+        }
+
+        prev_value
+    }
+
+    pub fn update<F>(&mut self, key: &K, mut updater: F) -> bool
+    where
+        F: FnMut(V) -> V,
+    {
+        let Some(prev_value) = self.map.get(key) else {
+            return false;
+        };
+
+        let prev_value = prev_value.to_owned();
+        let updated_value = updater(prev_value.clone());
+        if updated_value == prev_value {
+            return false;
+        }
+
+        self.map.insert(*key, updated_value.clone());
+        self.notify_observers(Event::Updated(key.to_owned(), prev_value, updated_value));
+
+        true
+    }
+
+    pub fn clone(&self) -> ObservableHashMap<K, V> {
+        ObservableHashMap::from(self.map.clone())
+    }
+}
+
+impl<K, V> From<ObservableHashMap<K, V>> for HashMap<K, V>
+where
+    K: Clone + Copy,
+    V: Clone,
+{
+    fn from(val: ObservableHashMap<K, V>) -> Self {
+        val.map
+    }
+}
+
+impl<K, V> Default for ObservableHashMap<K, V>
+where
+    K: Clone + Copy,
+    V: Clone,
+{
+    fn default() -> Self {
+        Self {
+            map: Default::default(),
+            observers: Default::default(),
+        }
+    }
+}

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, fmt::Display, net::SocketAddr, time::Instant};
 use crate::observable_hashmap::ObservableHashMap;
 
 pub type Peer = SocketAddr;
+pub type Fingerprint = u32;
 pub type KnownPeers = ObservableHashMap<Peer, PeerInfo>;
 
 /// PeerInfo

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -2,8 +2,10 @@ use bytes::Bytes;
 use serde_derive::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display, net::SocketAddr, time::Instant};
 
+use crate::observable_hashmap::ObservableHashMap;
+
 pub type Peer = SocketAddr;
-pub type KnownPeers = HashMap<Peer, PeerInfo>;
+pub type KnownPeers = ObservableHashMap<Peer, PeerInfo>;
 
 /// PeerInfo
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
✨ BONUS ✨ 
This PR turns all of Kaboodle's `info!` logging into `debug!` logging, and includes a rewritten version of the demo app that only prints out anything when something has actually changed. This makes it a lot more pleasant to watch! Behold: https://asciinema.org/a/572203

This introduces several new functions on `Kaboodle`:

- `discover_next_peer` returns a one-shot channel that receives the very next peer that is discovered
- `discover_peers` returns an unbounded channel that receives every peer as it is discovered
- `discover_depatures` returns an unbounded channel that receives every peer as it leaves
- `discover_fingerprint_changes` returns an unbounded channel that receives the fingerprint every time it changes

Use `discover_next_peer` if you really only care about the very next peer's existence and won't immediately want to discover the next peer after that. If you're doing something like waiting to discover a peer that have a certain property, it's not a good fit—due to the async nature of everything, it's possible for two back-to-back calls to `discover_next_peer` to miss the arrival of a peer if two or more show up roughly at the same moment. `discover_peers` does not have this issue.

This PR is a bit messier than I would prefer, because I initially implemented just the new peer discovery stuff, and I did that by explicitly calling a `handle_new_peer_discovered` function in all the right places. This made me nervous because it felt very brittle; any random refactoring could make it so we no longer invoked that function everywhere it needed to happen. I decided to create a wrapper around the `known_peers` HashMap that would send changes to an observer whenever the underlying HashMap was modified, because I felt more confident in our ability to implement that correctly. This ended up working marvelously well and I'm quite happy with the result—it ended up being trivial to add functions to discover peer departures and fingerprint changes as well. This should give us everything we need to implement consistent hash rings on top of Kaboodle meshes.