### PR TITLE
Grab bag: various improvements to fingerprinting, discovery events, and known peer sharing

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum KaboodleError {
+    #[error("Invalid operation: {0}")]
+    InvalidOperation(String),
+
     /// A conversion for std:io:Error
     #[error("std::io::Error: {0}")]
     IoError(#[from] std::io::Error),

--- a/src/kaboodle.rs
+++ b/src/kaboodle.rs
@@ -66,7 +66,10 @@ const REBROADCAST_INTERVAL: Duration = Duration::from_millis(10000);
 /// rather than guard against malicious tampering, CRC32 is a good fit: it's sufficiently robust for
 /// the task at hand, fast to compute, and has a very compact representation (a single u32).
 pub fn generate_fingerprint(known_peers: &KnownPeers) -> Fingerprint {
-    let mut hosts: Vec<String> = known_peers.keys().map(|peer| peer.to_string()).collect();
+    let mut hosts: Vec<String> = known_peers
+        .iter()
+        .map(|(peer, peer_info)| format!("{}/{}", peer, crc32fast::hash(&peer_info.identity)))
+        .collect();
     hosts.sort();
     crc32fast::hash(hosts.join(",").as_bytes())
 }

--- a/src/kaboodle.rs
+++ b/src/kaboodle.rs
@@ -307,7 +307,6 @@ impl KaboodleInner {
                     break bytes;
                 }
 
-                println!("TOO BIG {}", bytes.len());
                 // Alas, this payload is too large. Remove a peer at random and try again.
                 let peer_to_exclude = other_peers.keys().choose(&mut self.rng).unwrap().to_owned();
                 other_peers.remove(&peer_to_exclude);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,8 @@ fn handle_known_peers_events(
             known_peers.add_observer()
         };
 
+        let mut prev_fingerprint = 0;
+
         while let Some(event) = rx.recv().await {
             // We got an event; if there are more that are ready to receive, consume them all so we
             // can just send out a single fingerprint change event.
@@ -165,7 +167,10 @@ fn handle_known_peers_events(
                 // and the fingerprint would be `0` anyhow, so don't bother.
                 if !known_peers.is_empty() {
                     let fingerprint = generate_fingerprint(&known_peers);
-                    broadcast_to_channels(fingerprint, &mut fingerprint_tx);
+                    if fingerprint != prev_fingerprint {
+                        prev_fingerprint = fingerprint;
+                        broadcast_to_channels(fingerprint, &mut fingerprint_tx);
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,20 +164,22 @@ fn handle_known_peers_events(
             // If we didn't `continue` in one of the match arms, then send out a fingerprint change
             // notification.
             let mut fingerprint_tx = fingerprint_tx.lock().await;
-            if !fingerprint_tx.is_empty() {
-                let known_peers = known_peers.lock().await;
+            if fingerprint_tx.is_empty() {
+                continue;
+            }
 
-                // Make sure known_peers isn't empty; if it is, then we got called after Kaboodle
-                // was stopped when it happened to not know about any other peers. This isn't a
-                // particularly helpful situation in which to broadcast a fingerprint change event,
-                // and the fingerprint would be `0` anyhow, so don't bother.
-                if !known_peers.is_empty() {
-                    let fingerprint = generate_fingerprint(&known_peers);
-                    if fingerprint != prev_fingerprint {
-                        prev_fingerprint = fingerprint;
-                        broadcast_to_channels(fingerprint, &mut fingerprint_tx);
-                    }
-                }
+            // Make sure known_peers isn't empty; if it is, then we got called after Kaboodle
+            // was stopped when it happened to not know about any other peers. This isn't a
+            // particularly helpful situation in which to broadcast a fingerprint change event,
+            // and the fingerprint would be `0` anyhow, so don't bother.
+            let known_peers = known_peers.lock().await;
+            if known_peers.is_empty() {
+                continue;
+            }
+            let fingerprint = generate_fingerprint(&known_peers);
+            if fingerprint != prev_fingerprint {
+                prev_fingerprint = fingerprint;
+                broadcast_to_channels(fingerprint, &mut fingerprint_tx);
             }
         }
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,12 @@ fn handle_known_peers_events(
                         log::debug!("Peer updated; addr={addr}");
                     }
                     Event::Removed(addr) => {
+                        let known_peers = known_peers.lock().await;
+                        if known_peers.contains_key(&addr) {
+                            // Well, they got added back right away, apparently, so ignore this
+                            continue;
+                        }
+
                         log::debug!("Peer left; addr={addr}");
 
                         let mut departure_tx = departure_tx.lock().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,8 +158,15 @@ fn handle_known_peers_events(
             let mut fingerprint_tx = fingerprint_tx.lock().await;
             if !fingerprint_tx.is_empty() {
                 let known_peers = known_peers.lock().await;
-                let fingerprint = generate_fingerprint(&known_peers);
-                broadcast_to_channels(fingerprint, &mut fingerprint_tx);
+
+                // Make sure known_peers isn't empty; if it is, then we got called after Kaboodle
+                // was stopped when it happened to not know about any other peers. This isn't a
+                // particularly helpful situation in which to broadcast a fingerprint change event,
+                // and the fingerprint would be `0` anyhow, so don't bother.
+                if !known_peers.is_empty() {
+                    let fingerprint = generate_fingerprint(&known_peers);
+                    broadcast_to_channels(fingerprint, &mut fingerprint_tx);
+                }
             }
         }
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,9 +349,31 @@ impl Kaboodle {
         generate_fingerprint(&known_peers)
     }
 
+    /// Returns true if we are currently running (that is, if `.start()` has been called).
+    pub fn is_running(&self) -> bool {
+        self.self_addr.is_some()
+    }
+
     /// Get the address we use for one-to-one UDP messages, if we are currently running.
     pub fn self_addr(&self) -> Option<SocketAddr> {
         self.self_addr
+    }
+
+    /// Sets our identity payload to the given value. This can only be done while the mesh is not
+    /// running.
+    pub fn set_identity(&mut self, new_identity: Bytes) -> Result<(), KaboodleError> {
+        if self.is_running() {
+            // We can't update our identity value while we are a member of the mesh, because there
+            // is no message for "hey, my identity changed". This is just a decision made to keep
+            // things as simple as possible, and is one we can revisit later.
+            return Err(KaboodleError::InvalidOperation(String::from(
+                "Cannot change identity while the mesh is running; call .stop first",
+            )));
+        }
+
+        self.identity = new_identity;
+
+        Ok(())
     }
 
     /// Get our current list of known peers.

--- a/src/observable_hashmap.rs
+++ b/src/observable_hashmap.rs
@@ -95,6 +95,10 @@ where
         prev_value
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
     pub fn iter(&self) -> Iter<'_, K, V> {
         self.map.iter()
     }


### PR DESCRIPTION
The commit messages mostly tell the story here. In slightly expanded form:

- Bump incoming buffer size and make sure we never try to send a known peers message that's larger than it. This is gross and I hate it, but it's fine for now.
- I was seeing a few cases where "remove" events were showing up after the matching "add" events, so I added a check to make sure peer really was removed before broadcasting event
- Improvements to the fingerprint change event: consume all available ObservableHashMap events in a batch before sending out a fingerprint change event, don't broadcast fingerprint change if it didn't actually change, and don't send out a fingerprint change event if our known_peers map is empty (wherein the fingerprint will be 0). This latter case happens if you `.stop()` Kaboodle while it has no other known peers besides itself.
- Add ability to update our identity payload, and take the payload into account when generating the mesh fingerprint. This will be useful if we want to put things like our current load or memory usage or whatever into our identity payload. The only catch with the current implementation is that you have to do it while Kaboodle is stopped.
