### PR TITLE
Discovery without disruption

### DIFF
--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,75 @@
+use crate::errors::KaboodleError;
+use crate::networking::create_broadcast_sockets;
+use crate::structs::{SwimBroadcast, SwimEnvelope};
+use bytes::Bytes;
+use if_addrs::Interface;
+use tokio::time::timeout;
+
+use std::{
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
+use tokio::net::UdpSocket;
+
+/// How large a buffer to use when reading from our sockets; messages larger than this will be
+/// truncated.
+const INCOMING_BUFFER_SIZE: usize = 1024;
+
+/// How often to re-broadcast our Probe message if we don't get a response.
+const REBROADCAST_INTERVAL: Duration = Duration::from_millis(10000);
+
+/// Discovers one member of the mesh on the given port and interface, without actually joining
+/// the mesh. Use this if you simply need to discover a member of the mesh but do not want to
+/// join the mesh yourself.
+pub async fn discover_mesh_member(
+    broadcast_port: u16,
+    interface: Interface,
+) -> Result<(SocketAddr, Bytes), KaboodleError> {
+    let sock = {
+        let ip = interface.ip();
+        UdpSocket::bind(format!("{ip}:0")).await?
+    };
+    let self_addr = sock
+        .local_addr()
+        .expect("Failed to get local socket address");
+    let (_broadcast_in_sock, broadcast_out_sock, broadcast_addr) =
+        create_broadcast_sockets(&interface, &broadcast_port)?;
+
+    let mut buf = [0; INCOMING_BUFFER_SIZE];
+    let mut last_broadcast_time = Instant::now() - REBROADCAST_INTERVAL - Duration::from_secs(1);
+    let out_bytes =
+        bincode::serialize(&SwimBroadcast::Probe(self_addr)).expect("Failed to serialize");
+
+    loop {
+        if last_broadcast_time <= Instant::now() - REBROADCAST_INTERVAL {
+            log::debug!("Broadcasting probe message");
+            last_broadcast_time = Instant::now();
+            broadcast_out_sock
+                .send_to(&out_bytes, &broadcast_addr)
+                .await?;
+        }
+
+        let res = match timeout(REBROADCAST_INTERVAL, sock.recv_from(&mut buf)).await {
+            Err(_) => {
+                // No response in time; send another probe out and try again
+                continue;
+            }
+            Ok(res) => res,
+        };
+        let Ok((_len, sender)) = res else {
+            // Failed to read for some reason; this probably means that our socket got closed out
+            // from underneath us somehow, and it's not clear how we should deal with that.
+            // todo: figure out what to do if our socket closes
+            continue;
+        };
+
+        // Someone responded to our request
+        let Ok(env) = bincode::deserialize::<SwimEnvelope>(&buf) else {
+            // This would happen if there had been an incompatible change to SwimEnvelope between
+            // our code and which mesh member responded to us.
+            continue;
+        };
+
+        return Ok((sender, env.identity));
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,125 @@
+#![deny(unsafe_code)]
+#![warn(missing_debug_implementations, trivial_casts, unused_qualifications)]
+
+use bytes::Bytes;
+
+use crate::kaboodle::generate_fingerprint;
+use crate::observable_hashmap::Event;
+use crate::structs::{Fingerprint, KnownPeers, Peer};
+use std::sync::Arc;
+use tokio::sync::{mpsc::UnboundedSender, Mutex};
+
+pub type DiscoverySenders = Vec<UnboundedSender<(Peer, Bytes)>>;
+pub type DepartureSenders = Vec<UnboundedSender<Peer>>;
+pub type FingerprintSenders = Vec<UnboundedSender<Fingerprint>>;
+
+/// Listens to changes on the given known_peers ObservableHashMap and turns them into higher-level
+/// channel transmissions for peer arrivals, departures, and changes to the mesh fingerprint.
+pub fn handle_known_peers_events(
+    known_peers: Arc<Mutex<KnownPeers>>,
+    discovery_tx: Arc<Mutex<DiscoverySenders>>,
+    departure_tx: Arc<Mutex<DepartureSenders>>,
+    fingerprint_tx: Arc<Mutex<FingerprintSenders>>,
+) {
+    /// Sends the given payload to the given list of channels.
+    fn broadcast_to_channels<T>(payload: T, channels: &mut Vec<UnboundedSender<T>>)
+    where
+        T: Clone,
+    {
+        let mut closed_channels: Vec<usize> = vec![];
+        for (idx, tx) in channels.iter().enumerate() {
+            if tx.send(payload.clone()).is_err() {
+                // Channel must be closed ¯\_(ツ)_/¯
+                closed_channels.push(idx);
+            }
+        }
+        for idx in closed_channels {
+            channels.remove(idx);
+        }
+    }
+
+    tokio::spawn(async move {
+        let mut rx = {
+            let mut known_peers = known_peers.lock().await;
+            known_peers.add_observer()
+        };
+
+        let mut prev_fingerprint = 0;
+
+        while let Some(event) = rx.recv().await {
+            // We got an event; if there are more that are ready to receive, consume them all so we
+            // can just send out a single fingerprint change event.
+            let mut events = vec![event];
+            while let Ok(event) = rx.try_recv() {
+                events.push(event);
+            }
+
+            for event in events {
+                match event {
+                    Event::Added(addr) => {
+                        let identity = {
+                            let known_peers = known_peers.lock().await;
+                            let Some(peer_info) = known_peers.get(&addr) else {
+                                log::warn!("Received Event::Added but peer is not present in known_peers; this is a programming error");
+                                continue;
+                            };
+                            peer_info.identity.clone()
+                        };
+
+                        // Any time Kaboodle::discover_peer is called, it creates a new channel and adds the
+                        // sender to our `discovery_tx` map.
+                        let mut discovery_tx = discovery_tx.lock().await;
+
+                        log::debug!(
+                            "New peer discovered; addr={addr}; identity={identity:?}; listeners={}",
+                            discovery_tx.len()
+                        );
+
+                        broadcast_to_channels((addr, identity.clone()), &mut discovery_tx);
+                    }
+                    Event::Updated(addr, prev_value, new_value) => {
+                        if prev_value.identity == new_value.identity {
+                            // identity changes are the only thing that matters here; ignore if same
+                            continue;
+                        }
+
+                        log::debug!("Peer updated; addr={addr}");
+                    }
+                    Event::Removed(addr) => {
+                        let known_peers = known_peers.lock().await;
+                        if known_peers.contains_key(&addr) {
+                            // Well, they got added back right away, apparently, so ignore this
+                            continue;
+                        }
+
+                        log::debug!("Peer left; addr={addr}");
+
+                        let mut departure_tx = departure_tx.lock().await;
+                        broadcast_to_channels(addr, &mut departure_tx);
+                    }
+                }
+            }
+
+            // If we didn't `continue` in one of the match arms, then send out a fingerprint change
+            // notification.
+            let mut fingerprint_tx = fingerprint_tx.lock().await;
+            if fingerprint_tx.is_empty() {
+                continue;
+            }
+
+            // Make sure known_peers isn't empty; if it is, then we got called after Kaboodle
+            // was stopped when it happened to not know about any other peers. This isn't a
+            // particularly helpful situation in which to broadcast a fingerprint change event,
+            // and the fingerprint would be `0` anyhow, so don't bother.
+            let known_peers = known_peers.lock().await;
+            if known_peers.is_empty() {
+                continue;
+            }
+            let fingerprint = generate_fingerprint(&known_peers);
+            if fingerprint != prev_fingerprint {
+                prev_fingerprint = fingerprint;
+                broadcast_to_channels(fingerprint, &mut fingerprint_tx);
+            }
+        }
+    });
+}

--- a/src/kaboodle.rs
+++ b/src/kaboodle.rs
@@ -672,6 +672,9 @@ impl KaboodleInner {
         // In theory, we can run all of these things in parallel. This is left as an exercise for
         // the future; for now, it's nice to be able to reason about the logic of the mesh as a
         // series of individual steps happening over and over.
+        // In particular, it would be ideal if `handle_incoming_broadcasts` and
+        // `handle_incoming_messages` were pulled out of `tick` and were able to run more than once
+        // every PROTOCOL_PERIOD; this would decrease latency.
         self.maybe_broadcast_join().await;
         self.handle_incoming_broadcasts().await;
         self.handle_incoming_messages().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 
 use bytes::Bytes;
 use errors::KaboodleError;
+use events::{handle_known_peers_events, DepartureSenders, DiscoverySenders, FingerprintSenders};
 use if_addrs::Interface;
 use kaboodle::{generate_fingerprint, KaboodleInner};
 use networking::best_available_interface;
@@ -44,21 +45,16 @@ use observable_hashmap::ObservableHashMap;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use structs::{Fingerprint, KnownPeers, Peer, PeerInfo};
 use tokio::sync::{
-    mpsc::{Sender, UnboundedReceiver, UnboundedSender},
+    mpsc::{Sender, UnboundedReceiver},
     oneshot, Mutex,
 };
 
-use crate::observable_hashmap::Event;
-
 pub mod errors;
+mod events;
 mod kaboodle;
 pub mod networking;
-mod observable_hashmap;
+pub mod observable_hashmap;
 mod structs;
-
-type DiscoverySenders = Vec<UnboundedSender<(Peer, Bytes)>>;
-type DepartureSenders = Vec<UnboundedSender<Peer>>;
-type FingerprintSenders = Vec<UnboundedSender<Fingerprint>>;
 
 /// Data managed by a Kaboodle mesh client.
 #[derive(Debug)]
@@ -72,117 +68,6 @@ pub struct Kaboodle {
     fingerprint_tx: Arc<Mutex<FingerprintSenders>>,
     interface: Interface,
     identity: Bytes,
-}
-
-/// Listens to changes on the given known_peers ObservableHashMap and turns them into higher-level
-/// channel transmissions for peer arrivals, departures, and changes to the mesh fingerprint.
-fn handle_known_peers_events(
-    known_peers: Arc<Mutex<KnownPeers>>,
-    discovery_tx: Arc<Mutex<DiscoverySenders>>,
-    departure_tx: Arc<Mutex<DepartureSenders>>,
-    fingerprint_tx: Arc<Mutex<FingerprintSenders>>,
-) {
-    /// Sends the given payload to the given list of channels.
-    fn broadcast_to_channels<T>(payload: T, channels: &mut Vec<UnboundedSender<T>>)
-    where
-        T: Clone,
-    {
-        let mut closed_channels: Vec<usize> = vec![];
-        for (idx, tx) in channels.iter().enumerate() {
-            if tx.send(payload.clone()).is_err() {
-                // Channel must be closed ¯\_(ツ)_/¯
-                closed_channels.push(idx);
-            }
-        }
-        for idx in closed_channels {
-            channels.remove(idx);
-        }
-    }
-
-    tokio::spawn(async move {
-        let mut rx = {
-            let mut known_peers = known_peers.lock().await;
-            known_peers.add_observer()
-        };
-
-        let mut prev_fingerprint = 0;
-
-        while let Some(event) = rx.recv().await {
-            // We got an event; if there are more that are ready to receive, consume them all so we
-            // can just send out a single fingerprint change event.
-            let mut events = vec![event];
-            while let Ok(event) = rx.try_recv() {
-                events.push(event);
-            }
-
-            for event in events {
-                match event {
-                    Event::Added(addr) => {
-                        let identity = {
-                            let known_peers = known_peers.lock().await;
-                            let Some(peer_info) = known_peers.get(&addr) else {
-                                log::warn!("Received Event::Added but peer is not present in known_peers; this is a programming error");
-                                continue;
-                            };
-                            peer_info.identity.clone()
-                        };
-
-                        // Any time Kaboodle::discover_peer is called, it creates a new channel and adds the
-                        // sender to our `discovery_tx` map.
-                        let mut discovery_tx = discovery_tx.lock().await;
-
-                        log::debug!(
-                            "New peer discovered; addr={addr}; identity={identity:?}; listeners={}",
-                            discovery_tx.len()
-                        );
-
-                        broadcast_to_channels((addr, identity.clone()), &mut discovery_tx);
-                    }
-                    Event::Updated(addr, prev_value, new_value) => {
-                        if prev_value.identity == new_value.identity {
-                            // identity changes are the only thing that matters here; ignore if same
-                            continue;
-                        }
-
-                        log::debug!("Peer updated; addr={addr}");
-                    }
-                    Event::Removed(addr) => {
-                        let known_peers = known_peers.lock().await;
-                        if known_peers.contains_key(&addr) {
-                            // Well, they got added back right away, apparently, so ignore this
-                            continue;
-                        }
-
-                        log::debug!("Peer left; addr={addr}");
-
-                        let mut departure_tx = departure_tx.lock().await;
-                        broadcast_to_channels(addr, &mut departure_tx);
-                    }
-                }
-            }
-
-            // If we didn't `continue` in one of the match arms, then send out a fingerprint change
-            // notification.
-            let mut fingerprint_tx = fingerprint_tx.lock().await;
-            if fingerprint_tx.is_empty() {
-                continue;
-            }
-
-            // Make sure known_peers isn't empty; if it is, then we got called after Kaboodle
-            // was stopped when it happened to not know about any other peers. This isn't a
-            // particularly helpful situation in which to broadcast a fingerprint change event,
-            // and the fingerprint would be `0` anyhow, so don't bother.
-            let known_peers = known_peers.lock().await;
-            if known_peers.is_empty() {
-                continue;
-            }
-            let fingerprint = generate_fingerprint(&known_peers);
-            if fingerprint != prev_fingerprint {
-                prev_fingerprint = fingerprint;
-                broadcast_to_channels(fingerprint, &mut fingerprint_tx);
-            }
-        }
-    });
 }
 
 impl Kaboodle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,9 @@ impl Kaboodle {
     /// Get our current list of known peers and their current state.
     pub async fn peer_states(&self) -> HashMap<Peer, PeerInfo> {
         let known_peers = self.known_peers.lock().await;
-        known_peers.clone().into()
+        known_peers
+            .iter()
+            .map(|(peer, peer_info)| (peer.to_owned(), peer_info.to_owned()))
+            .collect::<HashMap<Peer, PeerInfo>>()
     }
 }

--- a/src/observable_hashmap.rs
+++ b/src/observable_hashmap.rs
@@ -140,10 +140,6 @@ where
 
         true
     }
-
-    pub fn clone(&self) -> ObservableHashMap<K, V> {
-        ObservableHashMap::from(self.map.clone())
-    }
 }
 
 impl<K, V> From<ObservableHashMap<K, V>> for HashMap<K, V>

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -61,6 +61,9 @@ pub enum SwimBroadcast {
     Join { addr: Peer, identity: Bytes },
     /// Announces that we believe the given Peer (not us) is down
     Failed(Peer),
+    /// Sent to attempt to discover any member of the mesh, without the intent to join the mesh
+    /// as a Peer.
+    Probe(SocketAddr),
 }
 
 /// The SwimEnvelope structure wraps all messages that we will send directly to another peer. In
@@ -71,6 +74,13 @@ pub struct SwimEnvelope {
     pub identity: Bytes,
     /// The actual message that the peer is sending.
     pub msg: SwimMessage,
+}
+
+/// Sent in response to a SwimBroadcast::Probe message, this is used to tell the probe initiator the
+/// identity of the responding node.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ProbeResponse {
+    pub identity: Bytes,
 }
 
 /// The SwimMessage enum represents messages we will send directly to another peer.


### PR DESCRIPTION
:eyes: https://asciinema.org/a/ecwxALtaQwZQsgnR1fttszVqs

## What
This introduces two new network messages:
- `SwimBroadcast::Probe`, sent by a machine that wants to discover a member of the mesh but does not what to join the mesh itself
- `ProbeResponse`, sent by a member of the mesh in response to the `::Probe` message

And one new public function:
- `Kaboodle::discover_mesh_member`

Keen-eyed pedants will observe that mesh probing is not part of the SWIM paper, and therefore putting it under the `SwimBroadcast` enum isn't technically correct. To these friendly pedants, I will point out that README.md describes this project as an _approximate_ implementation of the SWIM protocol. 😅 

## Why
As soon as @ceejbot started integrating kaboodle into serval-agent, it became apparent that having an ephemeral instance of the CLI tool join the mesh just to find a peer to send a job to didn't make any sense: joining the mesh is inherently a disruptive activity, as it causes every other peer in the mesh to have to discover the newcomer and settle onto a new mesh fingerprint. After the CLI tool exits, the same thing had to happen in reverse. This made no sense.

The new `Kaboodle::discover_mesh_member` function broadcasts out a `SwimBroadcast::Probe` message every 10 seconds until it gets a response. Originally, I _also_ had it snooping for `SwimBroadcast::Join` messages, in case it happened to hear a newcomer to the mesh as they arrived, but I decided to take that out for now because a brand new mesh member (who will not have an accurate view of the mesh for at least a few ticks) isn't the ideal mesh member to start talking to.

This insight made me realize that we probably don't want mesh members to respond to broadcast messages of any kind if their own mesh membership doesn't feel stable, for some definition of stable. e.g. Perhaps you have to have _N_ ticks in a row with no changes to your `known_peer` list before you're considered stable. I welcome any thoughts anyone else has over on https://github.com/serval/kaboodle/issues/18.