### PR TITLE
Use `tokio::select!` to handle incoming messages

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,6 +19,6 @@ pub enum KaboodleError {
     #[error("Unable to find interface number for the given networking interface")]
     UnableToFindInterfaceNumber,
 
-    #[error("Unable to stop: {0}")]
-    StoppingFailed(String),
+    #[error("Unable to stop")]
+    StoppingFailed,
 }

--- a/src/kaboodle.rs
+++ b/src/kaboodle.rs
@@ -22,7 +22,7 @@ use std::{
 };
 use tokio::{
     net::UdpSocket,
-    sync::{mpsc::Receiver, mpsc::Sender, Mutex},
+    sync::{oneshot::Receiver, oneshot::Sender, Mutex},
     time::sleep,
 };
 
@@ -132,7 +132,7 @@ impl KaboodleInner {
         let (broadcast_in_sock, broadcast_out_sock, broadcast_addr) =
             create_broadcast_sockets(interface, &broadcast_port)?;
 
-        let (cancellation_tx, cancellation_rx) = tokio::sync::mpsc::channel(1);
+        let (cancellation_tx, cancellation_rx) = tokio::sync::oneshot::channel();
 
         let mut instance = KaboodleInner {
             sock,


### PR DESCRIPTION
Previously, our tick logic looked something like this:

````
loop {
    1. maybe_broadcast_join
    2. handle_suspected_peers
    3. ping_random_peer
    4. handle_incoming_broadcasts
    5. handle_incoming_messages
    6. sleep(1)
}
````

Each of two `handle_incoming_...` functions would keep reading from their sockets for as long as there was data actually there, and then we'd repeat the whole loop all over again. While this is nice and easy to reason about, that once per second cadence means that on average, data would be waiting for `1s/2` → `0.5s` before it got handled, leading to a half a second latency on all of our network traffic.

This branch keeps the overall structure, but after we've done the first three parts of the tick, we run the two incoming data handlers in a loop in parallel. This has exactly the desired effect; on my test machine, I did 10 discovery probes in a loop and got an average duration of `0.9792s`, compared to `0.2491s` against this branch.

|         | before | after
| ------- | ------ | -----
|         | 0.783  | 0.248
|         | 1.001  | 0.248
|         | 1.001  | 0.249
|         | 1.001  | 0.246
|         | 1.001  | 0.245
|         | 1.001  | 0.245
|         | 1.001  | 0.254
|         | 1.001  | 0.248
|         | 1.001  | 0.256
|         | 1.001  | 0.252
| **average** | 0.9792 | 0.2491

Seems like a win.

Once happy side effect of this is that we can now increase the `PROTOCOL_PERIOD` (tick interval) from 1 second to whatever value we'd like without negatively impacting the responsiveness of mesh communications.