### PR TITLE
Track ping latency for known peers

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,6 +1,11 @@
 use bytes::Bytes;
 use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display, net::SocketAddr, time::Instant};
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
 
 use crate::observable_hashmap::ObservableHashMap;
 
@@ -13,6 +18,7 @@ pub type KnownPeers = ObservableHashMap<Peer, PeerInfo>;
 pub struct PeerInfo {
     pub identity: Bytes,
     pub state: PeerState,
+    pub latency: Option<Duration>,
 }
 
 /// PeerState represents our knowledge about the status of a given peer in the network at any given


### PR DESCRIPTION
Someday, we'd like to implement Vivaldi for our mesh. In the meantime, here's a simple stand-in to tide us over: whenever we receive a ping ack back from a peer, we update the new `latency` field for them in our known peers list. Any time we get a new data point, we mix it into the previously known ping time, giving 80% weight to the new ping time. This lets our latency estimates be fairly responsive to changes while also being resistant against weird blips.