### PR TITLE
Support for bootstrapping the mesh by sending pings to potential peers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 /target
+spawn.sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     io::{stdin, Read, Write},
+    net::SocketAddr,
     process::exit,
     sync::mpsc::{self, Receiver},
     thread::sleep,
@@ -44,6 +45,8 @@ struct Args {
     port: u16,
     #[arg(long, default_value = "false")]
     probe: bool,
+    #[arg(long)]
+    ping: Vec<SocketAddr>,
 }
 
 #[tokio::main]
@@ -112,6 +115,17 @@ async fn main() {
     println!("Interface: {} ({})", interface.name, interface.ip());
     println!("Address: {self_addr}");
     println!("Port: {}", args.port);
+
+    if !args.ping.is_empty() {
+        println!("Pinging the following peers to bootstrap:");
+        for addr in args.ping.iter() {
+            println!("- {addr}");
+        }
+        if let Err(err) = kaboodle.ping_addrs(args.ping).await {
+            eprintln!("Error pinging peers: {err}");
+            exit(0);
+        }
+    }
 
     let mut discovery_rx = kaboodle.discover_peers().unwrap();
     let mut departure_rx = kaboodle.discover_departures().unwrap();


### PR DESCRIPTION
We'd like to have some way of forming a mesh that spans LAN segments and/or tailnets, and generally offer support for working in environments where multicast is not an option.

This PR adds a mechanism for manually establishing a relationship with other nodes, given nothing more than a `SocketAddr`. As is explained in a comment, we can't pre-populate our known peers list solely based on a `SocketAddr`, but we _can_ send a `SwimMessage::Ping` to an arbitrary `SocketAddr`. Our incoming message handler already expects to receive messages from previously-unknown-to-us peers, so that's nothing out of the ordinary: we'll add the sender to our known peer list and send back a `SwimMessage::Ack`, and that will be enough for the original sender to join the same mesh that we are a member of.

[Here's a screencast showing this in action](https://asciinema.org/a/v2K99vz0wPp2zlmhCu5Paydlz): we start out by running two Kaboodle instances that are using different broadcast ports, which means they never find each other. However, if we tell one of the instances to manually ping the other, then they successfully form a mesh.

(Aside: in case it springs into anyone else's mind, this currently can't be used to bridge IPv4 and IPv6 meshes. We could theoretically add support for that in the future, but it would require keeping a separate set of sockets around for each stack.)