### PR TITLE
Ignore failure broadcasts from senders that are not members of the mesh

### DIFF
--- a/src/kaboodle.rs
+++ b/src/kaboodle.rs
@@ -254,10 +254,13 @@ impl KaboodleInner {
                         continue;
                     };
 
-                    // Note: unclear whether we should unilaterally trust this but ok
-                    log::debug!("Removing peer that we were told has failed {peer}");
                     let mut known_peers = self.known_peers.lock().await;
-                    known_peers.remove(&peer);
+                    if known_peers.contains_key(&sender) {
+                        log::debug!("Removing peer that we were told has failed {peer}");
+                        known_peers.remove(&peer);
+                    } else {
+                        log::debug!("{sender} told us that {peer} failed, but we are ignoring it because sender is not a mesh member and may be in a bad state");
+                    }
                     drop(known_peers);
                 }
                 SwimBroadcast::Join { addr, identity } => {


### PR DESCRIPTION
We have a strange bug on macOS right now, wherein sending broadcast UDP messages works but sending direct UDP messages does not. This is harmful to the operation of the mesh, because affected hosts can send broadcasts and _receive_ UDP messages, so they learn about mesh members, try to ping them and fail, and then broadcast out spurious "hey everybody, host _foo_ is down!" messages.

I need to root cause the issue, but this patch makes sense regardless: we shouldn't listen to a failure notification from someone who isn't already a known-to-us member of the mesh.

